### PR TITLE
Two FV3 dycore bug fixes for gsd/develop 2020/06/29

### DIFF
--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -3431,6 +3431,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
     print *, 'clwmr = ', liq_wat
     print *, ' o3mr = ', o3mr
     print *, 'ncnst = ', ncnst
+    print *, 'ntracers = ', ntracers
   endif
 
   if ( sphum/=1 ) then
@@ -6509,17 +6510,22 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
     je=bd%je
 
 ! FIXME: MPI_COMM_WORLD
+#ifdef OVERLOAD_R4
+#define _DYN_MPI_REAL MPI_REAL
+#else
+#define _DYN_MPI_REAL MPI_DOUBLE_PRECISION
+#endif
 
 
 ! Receive from north
     if( north_pe /= NULL_PE )then
-       call MPI_Irecv(buf1,ibufexch,MPI_REAL,north_pe,north_pe &
+       call MPI_Irecv(buf1,ibufexch,_DYN_MPI_REAL,north_pe,north_pe &
                      ,MPI_COMM_WORLD,ihandle1,irecv)
     endif
 
 ! Receive from south
     if( south_pe /= NULL_PE )then
-       call MPI_Irecv(buf2,ibufexch,MPI_REAL,south_pe,south_pe &
+       call MPI_Irecv(buf2,ibufexch,_DYN_MPI_REAL,south_pe,south_pe &
                      ,MPI_COMM_WORLD,ihandle2,irecv)
     endif
 
@@ -6551,7 +6557,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
          enddo
 
        enddo
-       call MPI_Issend(buf3,ic,MPI_REAL,north_pe,mype &
+       call MPI_Issend(buf3,ic,_DYN_MPI_REAL,north_pe,mype &
                       ,MPI_COMM_WORLD,ihandle3,isend)
     endif
 
@@ -6583,7 +6589,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
          enddo
 
        enddo
-       call MPI_Issend(buf4,ic,MPI_REAL,south_pe,mype &
+       call MPI_Issend(buf4,ic,_DYN_MPI_REAL,south_pe,mype &
                       ,MPI_COMM_WORLD,ihandle4,isend)
     endif
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -6483,7 +6483,6 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
     real, intent(inout) :: u   (bd%isd:bd%ied  ,bd%jsd:bd%jed+1,1:npz)
     real, intent(inout) :: v   (bd%isd:bd%ied+1,bd%jsd:bd%jed  ,1:npz)
 
-    integer,parameter :: ibufexch=2500000
     real, dimension(:), allocatable :: buf1,buf2,buf3,buf4
     integer :: ihandle1,ihandle2,ihandle3,ihandle4
     integer,dimension(MPI_STATUS_SIZE) :: istat
@@ -6524,13 +6523,13 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
 ! Receive from north
     if( north_pe /= NULL_PE )then
-       call MPI_Irecv(buf1,ibufexch,_DYN_MPI_REAL,north_pe,north_pe &
+       call MPI_Irecv(buf1,size(buf1),_DYN_MPI_REAL,north_pe,north_pe &
                      ,MPI_COMM_WORLD,ihandle1,irecv)
     endif
 
 ! Receive from south
     if( south_pe /= NULL_PE )then
-       call MPI_Irecv(buf2,ibufexch,_DYN_MPI_REAL,south_pe,south_pe &
+       call MPI_Irecv(buf2,size(buf2),_DYN_MPI_REAL,south_pe,south_pe &
                      ,MPI_COMM_WORLD,ihandle2,irecv)
     endif
 
@@ -6562,7 +6561,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
          enddo
 
        enddo
-       call MPI_Issend(buf3,ic,_DYN_MPI_REAL,north_pe,mype &
+       call MPI_Issend(buf3,size(buf3),_DYN_MPI_REAL,north_pe,mype &
                       ,MPI_COMM_WORLD,ihandle3,isend)
     endif
 
@@ -6594,7 +6593,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
          enddo
 
        enddo
-       call MPI_Issend(buf4,ic,_DYN_MPI_REAL,south_pe,mype &
+       call MPI_Issend(buf4,size(buf4),_DYN_MPI_REAL,south_pe,mype &
                       ,MPI_COMM_WORLD,ihandle4,isend)
     endif
 

--- a/model/fv_regional_bc.F90
+++ b/model/fv_regional_bc.F90
@@ -6484,7 +6484,7 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
     real, intent(inout) :: v   (bd%isd:bd%ied+1,bd%jsd:bd%jed  ,1:npz)
 
     integer,parameter :: ibufexch=2500000
-    real,dimension(ibufexch) :: buf1,buf2,buf3,buf4
+    real, dimension(:), allocatable :: buf1,buf2,buf3,buf4
     integer :: ihandle1,ihandle2,ihandle3,ihandle4
     integer,dimension(MPI_STATUS_SIZE) :: istat
     integer :: ic, i, j, k, is, ie, js, je
@@ -6509,13 +6509,18 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
     js=bd%js
     je=bd%je
 
+    allocate(buf1(1:24*npz))
+    allocate(buf2(1:36*npz))
+    allocate(buf3(1:36*npz))
+    allocate(buf4(1:24*npz))
+
 ! FIXME: MPI_COMM_WORLD
+
 #ifdef OVERLOAD_R4
 #define _DYN_MPI_REAL MPI_REAL
 #else
 #define _DYN_MPI_REAL MPI_DOUBLE_PRECISION
 #endif
-
 
 ! Receive from north
     if( north_pe /= NULL_PE )then
@@ -6654,6 +6659,11 @@ subroutine remap_scalar_nggps_regional_bc(Atm                         &
 
        enddo
     endif
+
+    deallocate(buf1)
+    deallocate(buf2)
+    deallocate(buf3)
+    deallocate(buf4)
 
   end subroutine exch_uv
 

--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -1549,7 +1549,7 @@ contains
                           isc, iec, jsc, jec, 0, npz, 1.)
           call prt_maxmin('Bottom DZ (m)', Atm(n)%delz(isc:iec,jsc:jec,npz),    &
                           isc, iec, jsc, jec, 0, 1, 1.)
-!         call prt_maxmin('Top DZ (m)', Atm(n)%delz(isc:iec,jsc:jec,1),    &
+!         call prt_maxmin('Top DZ (m)', Atm(n)%delz(is:ie,js:jec,1),    &
 !                         isc, iec, jsc, jec, 0, 1, 1.)
         endif
 
@@ -5572,7 +5572,7 @@ end subroutine eqv_pot
    real, intent(in):: grav, zvir, z_bot, z_top
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt
    real, intent(in), dimension(is:ie,js:je,km):: vort
-   real, intent(in):: delz(is-ng:ie+ng,js-ng:je+ng,km)
+   real, intent(in):: delz(is:ie,js:je,km)
    real, intent(in):: q(is-ng:ie+ng,js-ng:je+ng,km,*)
    real, intent(in):: phis(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in):: peln(is:ie,km+1,js:je)
@@ -5630,7 +5630,7 @@ end subroutine eqv_pot
    real, intent(in):: grav, zvir, z_bot, z_top
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt, w
    real, intent(in), dimension(is:ie,js:je,km):: vort
-   real, intent(in):: delz(is-ng:ie+ng,js-ng:je+ng,km)
+   real, intent(in):: delz(is:ie,js:je,km)
    real, intent(in):: q(is-ng:ie+ng,js-ng:je+ng,km,*)
    real, intent(in):: phis(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in):: peln(is:ie,km+1,js:je)


### PR DESCRIPTION
This PR contains https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/27 and https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/pull/25 for the gsd/develop branch to solve issues https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/issues/24 and https://github.com/NOAA-EMC/GFDL_atmos_cubed_sphere/issues/28 and allow us to reactivate the regression test `fv3_ccpp_gsd_sar_25km_debug` (issue https://github.com/NOAA-GSD/ufs-weather-model/issues/31).

Also included is a formal update from NOAA-EMC (which only contains parts of the changes described above).